### PR TITLE
Use posix paths for the href of the injected StyleX stylesheet to fix a Windows issue

### DIFF
--- a/.changeset/strange-pandas-visit.md
+++ b/.changeset/strange-pandas-visit.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-stylex": patch
+---
+
+Use posix paths for the href of the injected StyleX stylesheet to fix a Windows issue

--- a/packages/vite-plugin-stylex/src/index.mts
+++ b/packages/vite-plugin-stylex/src/index.mts
@@ -335,7 +335,12 @@ export default function styleXVitePlugin({
       }
 
       const { fileName } = asset;
-      const publicPath = path.join(publicBasePath, fileName);
+
+      // In Windows, we need to ensure we use posix paths to generate the correct URL for the <link> tag.
+      const publicPath = path.posix.join(
+        publicBasePath,
+        fileName.replace(/\\/g, "/")
+      );
 
       return [
         {


### PR DESCRIPTION
Fixes #15