### PR TITLE
Fix alias path on Windows to be '@/*' or '@src/*' instead of '@\\*' or '@src\\*'

### DIFF
--- a/.changeset/fresh-beers-care.md
+++ b/.changeset/fresh-beers-care.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-stylex": patch
+---
+
+Fix alias path on Windows to be '@/_' or '@src/_' instead of '@\\_' or '@src\\_'. Thanks to @DarkAng3L for the PR!

--- a/packages/vite-plugin-stylex/src/index.mts
+++ b/packages/vite-plugin-stylex/src/index.mts
@@ -220,7 +220,7 @@ export default function styleXVitePlugin({
         if (typeof viteAlias.find === "string") {
           // We need to convert Vite format to this plugin's format:
           // Example: @ -> @/*
-          const alias = path.join(viteAlias.find, "*");
+          const alias = viteAlias.find.concat("/*");
           aliases[alias] = [path.join(viteAlias.replacement, "*")];
         }
       }


### PR DESCRIPTION
Fix alias path on Windows, since unlike replacement which is a valid directory path, on Windows using path, the alias string gets escaped to '@\\*' or '@src\\*' instead of '@/*' or '@src/*'

This fixes issue: https://github.com/HorusGoul/vite-plugin-stylex/issues/39#issuecomment-2052631056