### PR TITLE
fix #78 rule is not iterable error

### DIFF
--- a/.changeset/few-pumpkins-occur.md
+++ b/.changeset/few-pumpkins-occur.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-stylex": patch
+---
+
+Remove undefined values from rules array before passing to stylex babel plugin.

--- a/packages/vite-plugin-stylex/src/main.mts
+++ b/packages/vite-plugin-stylex/src/main.mts
@@ -127,7 +127,7 @@ export default function styleXVitePlugin({
 
     // @ts-ignore
     const stylexCSS = stylexBabelPlugin.processStylexRules(
-      rules,
+      rules.filter(Boolean),
       true
     ) as string;
 


### PR DESCRIPTION
Remove `undefined` values from rules array before passing to stylex babel plugin.

Logging `rules` just before `stylexBabelPlugin.processStylexRules` is called shows it has many undefined values in the array, which it does not have in the initial run when starting the devserver.

Filtering out the undefined values appears to resolve the issue.

Unfortunately I can't say how to replicate this issue, though I do know my this past message that I'm not the only one to see it.. https://github.com/HorusGoul/vite-plugin-stylex/issues/24#issuecomment-1870977440

```
{
  rules: [
    undefined,
    undefined,
    [ 'xngnso2', [Object], 3000 ],
    [ 'x1evy7pa', [Object], 3000 ],
    [ 'x10ipcqr', [Object], 3000 ],
    undefined,
    undefined,
    undefined,
    [ 'x78zum5', [Object], 3000 ],
    [ 'xdt5ytf', [Object], 3000 ],
    [ 'x6s0dn4', [Object], 3000 ],
    [ 'xagnifm', [Object], 1200 ],
    undefined,
  ]
}
```